### PR TITLE
Clarify install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # Full_Noise
 
-Full_Noise is a node server that is used for viewing and uploading data for the cacophony project. It consists of a REST API and a basic web interface for viewing your data.
+Full_Noise is a Node server that is used for uploading, processing and
+retrieval of media collected for the Cacophony Project. It consists of
+a REST API and a basic web interface for viewing your data.
 
-## Setup  
-To setup Full_Noise you will need a PostgreSQL database and a LeoFS bucket setup first.
+## Setup
+
+To run Full_Noise you will need create a PostgreSQL database and a
+LeoFS bucket first.
 
 ### LeoFS Setup
 
@@ -15,22 +19,25 @@ To setup Full_Noise you will need a PostgreSQL database and a LeoFS bucket setup
 * Ensure that /etc/hosts has a `[bucket name].localhost` entry as described in the LeoFS documentation.
 
 ### PostgreSQL Setup
-A postgreSQL user needs to bet setup as the ower of a database and the postgis extension needs to be enabled on that database.
-There are more detaild instructions on how to do this online but here are some basic ones.
 
+A user account needs to be created within PostgreSQL as the owner of a
+database. The PostGIS extension also needs to be enabled on that
+database.
+
+* Choose a PostgreSQL database name, username & password
 * `sudo apt install postgresql-9.5 postgis --fix-missing`
-* `sudo su postgres`
+* `sudo -i -u postgres`
 * `psql`
-* `CREATE USER [your username] WITH PASSWORD '[your password]';`
-* `CREATE DATABASE [your database] WITH OWNER [your username];`
-* `\c [your database]`
+* `CREATE USER [username] WITH PASSWORD '[password]';`
+* `CREATE DATABASE [database] WITH OWNER [username];`
+* `\c [database]`
 * `CREATE EXTENSION postgis;`
 * `\q`
 
 ### Full_Noise setup.
-Install node v8 and npm.
 
-* `sudo apt install postgresql-server-dev-9.5 node-gyp`
+* Install Node version 8 or later from http://nodejs.org/
+* `sudo apt install postgresql-server-dev-9.5`
 * `git clone https://github.com/TheCacophonyProject/Full_Noise.git`
 * `cd Full_Noise`
 * `npm install`
@@ -39,5 +46,7 @@ Install node v8 and npm.
 * Start server with `node Server.js`
 
 ## License
-This project is licensed under the AGPL
+
+This project is licensed under the Affero General Public License
+(https://www.gnu.org/licenses/agpl-3.0.en.html).
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "knox": "^0.9.2",
     "morgan": "^1.7.0",
     "node-cmd": "^1.1.1",
+    "node-gyp": "^3.6.2",
     "passport": "^0.3.2",
     "passport-anonymous": "^1.0.1",
     "passport-jwt": "^2.1.0",


### PR DESCRIPTION
Cleaned up wording or added extra details to (hopefully) make installation a little easier.

Also moved node-gyp into package.json instead of asking the user to install it separately.