### PR TITLE
Added 'where', 'offset', 'limit', and 'Authorization' to the allowed …

### DIFF
--- a/Server.js
+++ b/Server.js
@@ -35,7 +35,7 @@ log.addExpressApp(app);
 app.all('*', function(req, res, next) {
   res.header('Access-Control-Allow-Origin', req.headers.origin);
   res.header('Access-Control-Allow-Methods', 'PUT, GET, POST, DELETE, OPTIONS');
-  res.header('Access-Control-Allow-Headers', 'Content-Type');
+  res.header('Access-Control-Allow-Headers', 'where, offset, limit, Authorization');
   next();
 });
 


### PR DESCRIPTION
…headers in CORS requests.

This allows the Web Interface to do API calls with these headers.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers